### PR TITLE
Add contact form using netlify forms and tailwind template

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint:fix": "vue-cli-service lint"
   },
   "dependencies": {
+    "@tailwindcss/forms": "^0.2.1",
     "autoprefixer": "^9",
     "core-js": "^3.4.3",
     "mini-css-extract-plugin": "^1.3.3",

--- a/public/form.html
+++ b/public/form.html
@@ -1,0 +1,6 @@
+<form name="ask-question" netlify netlify-honeypot="bot-field" hidden>
+    <input type="text" name="name" />
+    <input type="text" name="email" />
+    <textarea name="message"></textarea>
+</form>
+  

--- a/public/form.html
+++ b/public/form.html
@@ -1,4 +1,4 @@
-<form name="ask-question" netlify netlify-honeypot="bot-field" hidden>
+<form name="contact-form" netlify netlify-honeypot="bot-field" hidden>
     <input type="text" name="name" />
     <input type="text" name="email" />
     <textarea name="message"></textarea>

--- a/src/App.vue
+++ b/src/App.vue
@@ -6,6 +6,7 @@
     <Biography />
     <Projects />
     <Resume />
+    <ContactForm />
   </div>
 </template>
 
@@ -13,6 +14,7 @@
 import Biography from './components/Biography.vue';
 import Projects from './components/Projects.vue';
 import Resume from './components/Resume.vue';
+import ContactForm from './components/ContactForm.vue';
 
 export default {
   name: 'App',
@@ -20,6 +22,7 @@ export default {
     Biography,
     Projects,
     Resume,
+    ContactForm,
   },
 };
 </script>

--- a/src/components/Biography.vue
+++ b/src/components/Biography.vue
@@ -172,7 +172,7 @@
             <div class="mt-5 sm:mt-8 sm:flex sm:justify-center lg:justify-start">
               <div class="mt-3 sm:mt-0 sm:ml-3">
                 <a
-                  href="mailto:jackwilburn@tutanota.com"
+                  href="#contact"
                   class="w-full flex items-center justify-center px-8 py-3 border border-transparent text-base font-medium rounded-md text-green-700 bg-green-100 hover:bg-green-200 md:py-4 md:text-lg md:px-10"
                 >
                   Contact Me

--- a/src/components/ContactForm.vue
+++ b/src/components/ContactForm.vue
@@ -116,7 +116,9 @@ export default {
         this.errors.push('Message is missing, please enter a message');
       }
 
-      e.preventDefault();
+      if (this.errors.length > 0) {
+        e.preventDefault();
+      }
     },
   },
 };

--- a/src/components/ContactForm.vue
+++ b/src/components/ContactForm.vue
@@ -5,7 +5,7 @@
     </h2>
 
     <form
-      name="ask-question"
+      name="contact-form"
       method="POST"
       data-netlify="true"
       data-netlify-honeypot="bot-field"
@@ -13,7 +13,7 @@
       <input
         type="hidden"
         name="form-name"
-        value="ask-question"
+        value="contact-form"
       >
       <div class="shadow overflow-hidden sm:rounded-md">
         <div class="px-4 py-5 bg-white sm:p-6">

--- a/src/components/ContactForm.vue
+++ b/src/components/ContactForm.vue
@@ -1,0 +1,84 @@
+<template>
+  <div>
+    <h2 class="mt-5 text-3xl text-green-500">
+      Contact Form
+    </h2>
+
+    <form
+      name="ask-question"
+      method="POST"
+      data-netlify="true"
+      data-netlify-honeypot="bot-field"
+    >
+      <input
+        type="hidden"
+        name="form-name"
+        value="ask-question"
+      >
+      <div class="shadow overflow-hidden sm:rounded-md">
+        <div class="px-4 py-5 bg-white sm:p-6">
+          <div class="p-2 max-w-2xl mx-auto">
+            <label
+              for="name"
+              class="block text-sm font-medium text-gray-700"
+            >Your Name</label>
+            <input
+              id="name"
+              type="text"
+              name="name"
+              class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md"
+              placeholder="John Smith"
+            >
+          </div>
+
+          <div class="p-2 max-w-2xl mx-auto">
+            <label
+              for="email"
+              class="block text-sm font-medium text-gray-700"
+            >Your Email Address</label>
+            <input
+              id="email"
+              type="text"
+              name="email"
+              class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md"
+              placeholder="john.smith@gmail.com"
+            >
+          </div>
+
+          <div class="p-2 max-w-2xl mx-auto">
+            <label
+              for="message"
+              class="block text-sm font-medium text-gray-700"
+            >Message</label>
+            <textarea
+              id="message"
+              name="message"
+              rows="3"
+              class="shadow-sm focus:ring-indigo-500 focus:border-indigo-500 mt-1 block w-full sm:text-sm border-gray-300 rounded-md"
+              placeholder="Enter your message here"
+            />
+          </div>
+        </div>
+      </div>
+      <div class="px-4 py-6 bg-gray-50 sm:px-6">
+        <button
+          type="submit"
+          class="inline-flex justify-center py-2 px-8 border border-transparent shadow-sm text-sm font-medium rounded-md text-green-700 bg-green-100 hover:bg-green-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+        >
+          Send
+        </button>
+      </div>
+    </form>
+  </div>
+</template>
+<script>
+export default {
+  name: 'ContactForm',
+
+  methods: {
+    validate() {
+      //
+    },
+  },
+};
+</script>

--- a/src/components/ContactForm.vue
+++ b/src/components/ContactForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div id="contact">
     <h2 class="mt-5 text-3xl text-green-500">
       Contact Form
     </h2>

--- a/src/components/ContactForm.vue
+++ b/src/components/ContactForm.vue
@@ -9,6 +9,7 @@
       method="POST"
       data-netlify="true"
       data-netlify-honeypot="bot-field"
+      @submit="validate"
     >
       <input
         type="hidden"
@@ -24,6 +25,7 @@
             >Your Name</label>
             <input
               id="name"
+              v-model="name"
               type="text"
               name="name"
               class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md"
@@ -38,6 +40,7 @@
             >Your Email Address</label>
             <input
               id="email"
+              v-model="email"
               type="text"
               name="email"
               class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md"
@@ -52,12 +55,20 @@
             >Message</label>
             <textarea
               id="message"
+              v-model="message"
               name="message"
               rows="3"
               class="shadow-sm focus:ring-indigo-500 focus:border-indigo-500 mt-1 block w-full sm:text-sm border-gray-300 rounded-md"
               placeholder="Enter your message here"
             />
           </div>
+
+          <p
+            v-for="(error, index) of errors"
+            :key="index"
+          >
+            {{ error }}
+          </p>
         </div>
       </div>
       <div class="px-4 py-6 bg-gray-50 sm:px-6">
@@ -75,9 +86,37 @@
 export default {
   name: 'ContactForm',
 
+  data() {
+    return {
+      name: '',
+      email: '',
+      message: '',
+      errors: [],
+    };
+  },
+
   methods: {
-    validate() {
-      //
+    validate(e) {
+      this.errors = [];
+
+      // Check name
+      if (this.name === '') {
+        this.errors.push('Name is missing, please enter your full name');
+      }
+
+      // Check email
+      if (this.email === '') {
+        this.errors.push('Email is missing, please enter your email');
+      } else if (!/^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/.test(this.email)) {
+        this.errors.push('Email is invalid, please check your spelling');
+      }
+
+      // Check message
+      if (this.message === '') {
+        this.errors.push('Message is missing, please enter a message');
+      }
+
+      e.preventDefault();
     },
   },
 };

--- a/src/components/Resume.vue
+++ b/src/components/Resume.vue
@@ -5,7 +5,7 @@
     </h2>
 
     <!-- Jobs -->
-    <div class="text-left p-4 max-w-4xl mx-auto pb-8 sm:pb-16 md:pb-20 lg:pb-28 xl:pb-32">
+    <div class="text-left p-4 max-w-4xl mx-auto">
       <h3 class="mt-4 text-xl font-bold">
         Professional Experience
       </h3>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,5 +8,8 @@ module.exports = {
   variants: {
     extend: {},
   },
-  plugins: [],
+  plugins: [
+    // eslint-disable-next-line global-require
+    require('@tailwindcss/forms'),
+  ],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -939,6 +939,13 @@
   resolved "https://registry.yarnpkg.com/@soda/get-current-script/-/get-current-script-1.0.2.tgz#a53515db25d8038374381b73af20bb4f2e508d87"
   integrity sha512-T7VNNlYVM1SgQ+VsMYhnDkcGmWhQdL0bDyGm5TlQ3GBXnJscEClUUOKduWTmm2zCnvNLC1hc3JpuXjs/nFOc5w==
 
+"@tailwindcss/forms@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/forms/-/forms-0.2.1.tgz#3244b185854fae1a7cbe8d2456314d8b2d98cf43"
+  integrity sha512-czfvEdY+J2Ogfd6RUSr/ZSUmDxTujr34M++YLnp2cCPC3oJ4kFvFMaRXA6cEXKw7F1hJuapdjXRjsXIEXGgORg==
+  dependencies:
+    mini-svg-data-uri "^1.2.3"
+
 "@types/anymatch@*":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
@@ -1244,7 +1251,7 @@
     "@vue/babel-plugin-transform-vue-jsx" "^1.2.1"
     camelcase "^5.0.0"
 
-"@vue/cli-overlay@^4.5.9":
+"@vue/cli-overlay@^4.5.3":
   version "4.5.9"
   resolved "https://registry.yarnpkg.com/@vue/cli-overlay/-/cli-overlay-4.5.9.tgz#393418b6d5eaf8638f599c939cb425838257d37c"
   integrity sha512-E2PWv6tCdUz+eEDj2Th2oxiKmzMe02qi0PcxiNaO7oaqggmEOrp1rLgop7DWpiLDBiqUZk2x0vjK/q2Tz8z/eg==
@@ -1274,22 +1281,22 @@
     webpack "^4.0.0"
     yorkie "^2.0.0"
 
-"@vue/cli-plugin-router@^4.5.9":
+"@vue/cli-plugin-router@^4.5.3":
   version "4.5.9"
   resolved "https://registry.yarnpkg.com/@vue/cli-plugin-router/-/cli-plugin-router-4.5.9.tgz#b3d23a8083d26a81bd09bf9c8d010a3e4e4b13d0"
   integrity sha512-eBBfbZpQ1sJrdlx8i7iReFxSnuzwmrv+s2OCT3kjBd6uWRqGnD4VihpS4srC7vZLzDQrDplumSn0a93L9Qf3wQ==
   dependencies:
     "@vue/cli-shared-utils" "^4.5.9"
 
-"@vue/cli-plugin-vuex@^4.5.9":
+"@vue/cli-plugin-vuex@^4.5.3":
   version "4.5.9"
   resolved "https://registry.yarnpkg.com/@vue/cli-plugin-vuex/-/cli-plugin-vuex-4.5.9.tgz#5ae8f1500c7e29406b02fac82cceaeab86c1e83a"
   integrity sha512-mFNIJhYiJjzCgytkDHX00ROy5Yzl7prkZpUbeDE0biwcLteMf2s3qZVbESOQl6GcviqcfEt2f3tHQQtLNa+OLg==
 
-"@vue/cli-service@^4.5.3":
-  version "4.5.9"
-  resolved "https://registry.yarnpkg.com/@vue/cli-service/-/cli-service-4.5.9.tgz#3ca3112a44183caace411d51d0b6a616e2e197b1"
-  integrity sha512-E3XlfM0q+UnnjbC9rwLIWNo2umZCRwnlMJY0KOhY1hFvqisGIYzFmQQ4o01KGyTx2BZNMuQg7Kw+BZ5gyM1Wig==
+"@vue/cli-service@4.5.3":
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/@vue/cli-service/-/cli-service-4.5.3.tgz#4cf269a86d3d78c0568ed77908c18e9b970ad2ff"
+  integrity sha512-AufXUW+n8Wh9pqJu1v9Uh+6Sx6HdDrRopHMhUB/FrXhLFFPXRDo+s9zFC5QuJSt+roR0oBwmAp/x6KvBFQosIQ==
   dependencies:
     "@intervolga/optimize-cssnano-plugin" "^1.0.5"
     "@soda/friendly-errors-webpack-plugin" "^1.7.1"
@@ -1297,10 +1304,10 @@
     "@types/minimist" "^1.2.0"
     "@types/webpack" "^4.0.0"
     "@types/webpack-dev-server" "^3.11.0"
-    "@vue/cli-overlay" "^4.5.9"
-    "@vue/cli-plugin-router" "^4.5.9"
-    "@vue/cli-plugin-vuex" "^4.5.9"
-    "@vue/cli-shared-utils" "^4.5.9"
+    "@vue/cli-overlay" "^4.5.3"
+    "@vue/cli-plugin-router" "^4.5.3"
+    "@vue/cli-plugin-vuex" "^4.5.3"
+    "@vue/cli-shared-utils" "^4.5.3"
     "@vue/component-compiler-utils" "^3.1.2"
     "@vue/preload-webpack-plugin" "^1.1.0"
     "@vue/web-component-wrapper" "^1.2.0"
@@ -1347,9 +1354,9 @@
     webpack-dev-server "^3.11.0"
     webpack-merge "^4.2.2"
   optionalDependencies:
-    vue-loader-v16 "npm:vue-loader@^16.0.0-beta.7"
+    vue-loader-v16 "npm:vue-loader@^16.0.0-beta.3"
 
-"@vue/cli-shared-utils@^4.5.9":
+"@vue/cli-shared-utils@^4.5.3", "@vue/cli-shared-utils@^4.5.9":
   version "4.5.9"
   resolved "https://registry.yarnpkg.com/@vue/cli-shared-utils/-/cli-shared-utils-4.5.9.tgz#487cea4b4282f4dff907ee7d8abba8dd0dd03ccd"
   integrity sha512-anvsrv+rkQC+hgxaT2nQQxnSWSsIzyysZ36LO7qPjXvDRBvcvKLAAviFlUkYbZ+ntbV8puzJ3zw+gUhQw4SEVA==
@@ -5790,6 +5797,11 @@ mini-css-extract-plugin@^1.3.3:
     schema-utils "^3.0.0"
     webpack-sources "^1.1.0"
 
+mini-svg-data-uri@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/mini-svg-data-uri/-/mini-svg-data-uri-1.2.3.tgz#e16baa92ad55ddaa1c2c135759129f41910bc39f"
+  integrity sha512-zd6KCAyXgmq6FV1mR10oKXYtvmA9vRoB6xPSTUJTbFApCtkefDnYueVR1gkof3KcdLZo1Y8mjF2DFmQMIxsHNQ==
+
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
@@ -8797,10 +8809,10 @@ vue-hot-reload-api@^2.3.0:
   resolved "https://registry.yarnpkg.com/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz#532955cc1eb208a3d990b3a9f9a70574657e08f2"
   integrity sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog==
 
-"vue-loader-v16@npm:vue-loader@^16.0.0-beta.7":
-  version "16.1.1"
-  resolved "https://registry.yarnpkg.com/vue-loader/-/vue-loader-16.1.1.tgz#f5b286d60ac6886684c63a17a184391cc9e0199a"
-  integrity sha512-wz/+HFg/3SBayHWAlZXARcnDTl3VOChrfW9YnxvAweiuyKX/7IGx1ad/4yJHmwhgWlOVYMAbTiI7GV8G33PfGQ==
+"vue-loader-v16@npm:vue-loader@^16.0.0-beta.3":
+  version "16.1.2"
+  resolved "https://registry.yarnpkg.com/vue-loader/-/vue-loader-16.1.2.tgz#5c03b6c50d2a5f983c7ceba15c50d78ca2b298f4"
+  integrity sha512-8QTxh+Fd+HB6fiL52iEVLKqE9N1JSlMXLR92Ijm6g8PZrwIxckgpqjPDWRP5TWxdiPaHR+alUWsnu1ShQOwt+Q==
   dependencies:
     chalk "^4.1.0"
     hash-sum "^2.0.0"


### PR DESCRIPTION
Closes #12

Adds a tailwindcss form that can be submitted through netlify. This will take in name, email, and a message and should hopefully be visible on the netlify dashboard (and maybe even will send an email to me).

TODO:
- [x] Test the form works
- [x] Add some validation
- [x] Link contact me to the form, not my email
- [x] Modify name of form from ask-question