### PR TITLE
Stop logo from moving on mobile nav open

### DIFF
--- a/src/components/Biography.vue
+++ b/src/components/Biography.vue
@@ -92,10 +92,10 @@
             v-if="open"
             class="rounded-lg shadow-md bg-white ring-1 ring-black ring-opacity-5 overflow-hidden dark:bg-black"
           >
-            <div class="px-5 pt-4 flex items-center justify-between">
+            <div class="px-2 sm:px-4 pt-4 flex items-center justify-between">
               <div>
                 <img
-                  class="h-8 w-auto"
+                  class="h-8 w-auto sm:h-10"
                   src="../assets/logo.svg"
                   alt=""
                 >


### PR DESCRIPTION
Closes #8

I altered the padding to stop the logo from moving as the nav bar is opened up. I also adjusted the size of the logo in the nav bar as the screen gets larger, thus reducing another piece of the movement