### PR TITLE
Refactor project cards to fix link hover, general design issues, and dark mode colors

### DIFF
--- a/src/components/ProjectCard.vue
+++ b/src/components/ProjectCard.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="mt-4 p-4 shadow-lg border-2 border-gray-50 dark:border-gray-800 rounded-none md:max-w-sm md:mx-auto">
-    <div class="font-bold text-xl mb-2">
+  <div class="mt-4 p-4 shadow-lg border-2 border-gray-50 dark:border-gray-800 rounded-md md:max-w-sm md:mx-auto bg-white dark:bg-gray-900">
+    <div class="font-bold text-xl mb-2 dark:text-gray-300">
       {{ title }}
     </div>
     <p class="text-gray-500 text-base">

--- a/src/components/ProjectCard.vue
+++ b/src/components/ProjectCard.vue
@@ -76,7 +76,7 @@ export default {
 
   methods: {
     muted(value) {
-      return value === null ? 'text-gray-200 dark:text-gray-800' : 'dark:text-gray-500';
+      return value === null ? 'text-gray-200 dark:text-gray-800' : 'text-gray-500 hover:text-gray-900 dark:text-gray-500 dark:hover:text-gray-300';
     },
   },
 };


### PR DESCRIPTION
Closes 25
Closes 26

Fixes the hover color for links, rounds the corners for the cards, and fixes the coloring of them in dark mode