### PR TITLE
Update github action to v3 and use node lts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,14 +11,15 @@ on:
 
 jobs:
   build-and-test:
-    name: Lint and build on Ubuntu - Node 16
+    name: Lint and build on Ubuntu - Node latest lts
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v3
       with:
-        node-version: '16'
+        node-version: 'lts/*'
         cache: 'yarn'
+        check-latest: true
 
     - run: yarn install
     - run: yarn lint


### PR DESCRIPTION
Closes #61 

Updated node version for the github action that tests the website
